### PR TITLE
Fix conditional `html` tag insertion

### DIFF
--- a/templates/layout.mustache
+++ b/templates/layout.mustache
@@ -13,9 +13,9 @@
 <!--[if IE 9]>
 <html class="no-js ie ie9" lang="en">
 <![endif]-->
-<!--[if gt IE 9]>
+<!--[if (gt IE 9)|!(IE)]><!-->
 <html class="no-js" lang="en">
-<![endif]-->
+<!--<![endif]-->
 <head>
 	<meta charset="utf-8">
 	<title>{{makeParentTitle}} {{#if title}}- {{title}} {{else}} {{#if name}}- {{name}}{{/if}}{{/if}}</title>


### PR DESCRIPTION
It was not taking into account non IE browsers, causing the browser to insert an `html` tag without the `lang` property.

<img width="482" alt="screen shot 2017-05-03 at 12 15 14" src="https://cloud.githubusercontent.com/assets/724877/25675051/4b9eec52-2ffa-11e7-9194-0e90fad4fd79.png">

Closes stealjs/stealjs#44